### PR TITLE
Adding a silent error for the new-item

### DIFF
--- a/PowerShell/FSLogixSetup.ps1
+++ b/PowerShell/FSLogixSetup.ps1
@@ -58,7 +58,7 @@ else {
         -BackgroundColor Black `
         "c:\temp\wvd directory already exists"
 }
-New-Item -Path c:\ -Name New-WVDSessionHost.log -ItemType File
+New-Item -Path c:\ -Name New-WVDSessionHost.log -ItemType File -ErrorAction SilentlyContinue
 Add-Content `
 -LiteralPath C:\New-WVDSessionHost.log `
 "


### PR DESCRIPTION
Without this, an error is outputted saying the file already exists. Could also use -Force if that would be desired behavior instead.